### PR TITLE
ci: add CI workflow for tests, clippy, and fmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - run: cargo fmt --check
+      - run: cargo clippy --workspace -- -D warnings
+      - run: cargo test --workspace


### PR DESCRIPTION
Adds a GitHub Actions CI workflow that runs on push to master and on PRs:

- `cargo fmt --check` — formatting
- `cargo clippy --workspace -- -D warnings` — linting  
- `cargo test --workspace` — tests

Uses `dtolnay/rust-toolchain@stable` with clippy and rustfmt components.